### PR TITLE
Fix typo in property name parserOptions

### DIFF
--- a/react.js
+++ b/react.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: 'eslint-config-exponent',
 
-  parseOptions: {
+  parserOptions: {
     ecmaFeatures: {
       jsx: true,
     },


### PR DESCRIPTION
eslint 4.0.0 validates eslint config keys, and caught this bug.

It's correct in the base file: https://github.com/expo/eslint-config-exponent/blob/master/eslintrc.js#L4

@skevy @ide since you were the last ones to touch this repo.