### PR TITLE
Updated installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Shared ESLint configs for Node, Web, React Native, and Expo projects.
 ## Installation
 
 ```sh
-yarn add --dev eslint-config-expo
+yarn add --dev eslint-config-universe
 ```
 
 You will also need to install `eslint` and `prettier`:


### PR DESCRIPTION
For some reason this readme still references `eslint-config-expo` in install script, I believe it should be `-universe`?
npm seems to reflect it correctly: https://www.npmjs.com/package/eslint-config-universe