### PR TITLE
Remove the no-control-regex rule

### DIFF
--- a/shared/core.js
+++ b/shared/core.js
@@ -40,6 +40,7 @@ module.exports = {
     'no-cond-assign': 'warn',
     'no-const-assign': 'error',
     'no-constant-condition': 'warn',
+    'no-control-regex': 'off',
     'no-debugger': 'warn',
     'no-delete-var': 'error',
     'no-dupe-args': 'error',

--- a/shared/core.js
+++ b/shared/core.js
@@ -40,7 +40,6 @@ module.exports = {
     'no-cond-assign': 'warn',
     'no-const-assign': 'error',
     'no-constant-condition': 'warn',
-    'no-control-regex': 'warn',
     'no-debugger': 'warn',
     'no-delete-var': 'error',
     'no-dupe-args': 'error',


### PR DESCRIPTION
The no-control-regex rule forbids matching control characters with a regex, e.g. `chunk.msg.match(/^[\u001b]/)` (real life example from https://github.com/expo/expo-cli/blob/f5e12c420a8d3e474d59c93925af69a0c172d99b/packages/xdl/src/logs/PackagerLogsStream.js#L532-L536).

I don't see a good reason why Unicode escape sequences of control characters should be forbidden in regular expressions.